### PR TITLE
Fix option --diffhitlist

### DIFF
--- a/correct-results-008.txt
+++ b/correct-results-008.txt
@@ -1,0 +1,17 @@
+Flawfinder version 2.0.9, (C) 2001-2017 David A. Wheeler.
+Showing hits not in test-saved-hitlist-008.txt
+Number of rules (primarily dangerous function names) in C/C++ ruleset: 223
+
+ANALYSIS SUMMARY:
+
+No hits found.
+Lines analyzed = 121
+Physical Source Lines of Code (SLOC) = 84
+Hits@level = [0]   0 [1]   0 [2]   0 [3]   0 [4]   0 [5]   0
+Hits@level+ = [0+]   0 [1+]   0 [2+]   0 [3+]   0 [4+]   0 [5+]   0
+Hits/KSLOC@level+ = [0+]   0 [1+]   0 [2+]   0 [3+]   0 [4+]   0 [5+]   0
+Suppressed hits = 2 (use --neverignore to show them)
+Minimum risk level = 1
+There may be other security vulnerabilities; review your code!
+See 'Secure Programming HOWTO'
+(https://dwheeler.com/secure-programs) for more information.

--- a/flawfinder
+++ b/flawfinder
@@ -394,6 +394,16 @@ class Hit(object):
     def __getitem__(self, X):  # Define this so this works: "%(line)" % hit
         return getattr(self, X)
 
+    def __eq__(self, other):
+        return (self.filename == other.filename
+                and self.line == other.line
+                and self.column == other.column
+                and self.level == other.level
+                and self.name == other.name)
+
+    def __ne__(self, other):
+        return not self == other
+
     # return CWEs
     def cwes(self):
         result = find_cwe_pattern.search(self.warning)

--- a/makefile
+++ b/makefile
@@ -181,11 +181,21 @@ test_007: setup.py
 	@test "`$(PYTHON) setup.py --license`" = 'GPL-2.0+'
 	@test "`$(PYTHON) setup.py --author`" = 'David A. Wheeler'
 
+test_008: flawfinder test.c
+	@echo 'test_008 (diff hitlist)'
+	@$(PYTHON) ./flawfinder -S -DC --quiet \
+	  --savehitlist test-saved-hitlist-008.txt \
+	  test.c > test-junk-008.txt
+	@$(PYTHON) ./flawfinder -S -C --quiet --omittime \
+	  --diffhitlist  test-saved-hitlist-008.txt test.c > \
+	  test-results-008.txt
+	@diff -u correct-results-008.txt test-results-008.txt
+
 # Run all tests on *one* version of Python;
 # output shows differences from expected results.
 # If everything works as expected, it just prints test numbers.
 # Set PYTHON as needed, including to ""
-test: test_001 test_002 test_003 test_004 test_005 test_006 test_007
+test: test_001 test_002 test_003 test_004 test_005 test_006 test_007 test_008
 	@echo 'All tests pass!'
 
 # Usual check routine. Run all tests using *both* python2 and python3.
@@ -204,6 +214,7 @@ test-is-correct: test-results.txt
 	cp -p test-results-004.txt correct-results-004.txt
 	cp -p test-results-005.txt correct-results-005.txt
 	cp -p test-results-006.txt correct-results-006.txt
+	cp -p test-results-008.txt correct-results-008.txt
 
 profile:
 	/usr/lib/python1.5/profile.py ./flawfinder > profile-results $(SAMPLE_DIR)/*/*.[ch] > profile-results 


### PR DESCRIPTION
Add __eq__() method to Hit class to allow for comparison of instances.
If absent, comparison is done on instance id and not fields.

Should fix #8 