### PR TITLE
Fix misrecognized number separator in C++14

### DIFF
--- a/flawfinder
+++ b/flawfinder
@@ -1461,6 +1461,7 @@ def process_c_file(f, patch_infos):
     linenumber = 1
     ignoreline = -1
 
+    cpplanguage = f.endswith(".cpp") or f.endswith(".cxx") or f.endswith(".cc")
     incomment = 0
     instring = 0
     linebegin = 1
@@ -1644,9 +1645,12 @@ def process_c_file(f, patch_infos):
                                                      startpos + max_lookahead]
                             hit.hook(hit)
                 elif p_digits.match(c):
-                    while i < len(text) and p_digits.match(
-                            text[i]):  # Process a number.
-                        i += 1
+                    while i < len(text): # Process a number.
+                        # C does not have digit separator
+                        if p_digits.match(text[i]) or (cpplanguage and text[i] == "'"):
+                            i += 1
+                        else:
+                            break
                 # else some other character, which we ignore.
                 # End of loop through text. Wrap up.
     if codeinline:

--- a/test/makefile
+++ b/test/makefile
@@ -66,11 +66,21 @@ test_008: $(FLAWFINDER) test.c
 	  test-results-008.txt
 	@diff -u correct-results-008.txt test-results-008.txt
 
+test_009: $(FLAWFINDER) test-cpp-digit-separator.cpp
+	@echo 'test_009 (C++ digit separator)'
+# C++ file should have no problem recognizing ' as digit separator
+	@$(PYTHON) $(FLAWFINDER) test-cpp-digit-separator.cpp > /dev/null
+# C file should fail with unterminated char literal error
+	@$(PYTHON) $(FLAWFINDER) test-cpp-digit-separator.c 2>&1 \
+		| grep 'File ended while in string.' \
+		> /dev/null
+
 # Run all tests on *one* version of Python;
 # output shows differences from expected results.
 # If everything works as expected, it just prints test numbers.
 # Set PYTHON as needed, including to ""
-test: test_001 test_002 test_003 test_004 test_005 test_006 test_007 test_008
+test: test_001 test_002 test_003 test_004 test_005 test_006 test_007 test_008 \
+	  test_009
 	@echo 'All tests pass!'
 
 # Usual check routine. Run all tests using *both* python2 and python3.

--- a/test/test-cpp-digit-separator.c
+++ b/test/test-cpp-digit-separator.c
@@ -1,0 +1,1 @@
+int main() { return 0'000; }

--- a/test/test-cpp-digit-separator.cpp
+++ b/test/test-cpp-digit-separator.cpp
@@ -1,0 +1,1 @@
+int main() { return 0'000; }


### PR DESCRIPTION
Since C++14, number literal can have the `'` inside to separate digits. This PR do the minimum to prevent misrecognized digit separator as the beginning of character literal.