### PR TITLE
Add Sarif friendly opaque rule id

### DIFF
--- a/flawfinder
+++ b/flawfinder
@@ -379,7 +379,7 @@ class Hit(object):
 
     def __init__(self, data):
         hook, level, warning, suggestion, category, url, other, ruleid = data
-        self.hook, self.level = hook, level
+        self.hook, self.level, self.defaultlevel = hook, level, level
         self.warning, self.suggestion = warning, suggestion
         self.category, self.url = category, url
         self.ruleid = ruleid
@@ -427,7 +427,7 @@ class Hit(object):
     # Show as CSV format
     def show_csv(self):
         csv_writer.writerow([
-            self.filename, self.line, self.column, self.level, self.category,
+            self.filename, self.line, self.column, self.defaultlevel, self.level, self.category,
             self.name, self.warning + ".", self.suggestion + "." if self.suggestion else "", self.note,
             self.cwes(), self.context_text, self.fingerprint(),
             version, self.ruleid, self.helpuri()
@@ -1786,7 +1786,7 @@ def display_header():
     global displayed_header
     if csv_output:
         csv_writer.writerow([
-            'File', 'Line', 'Column', 'Level', 'Category', 'Name', 'Warning',
+            'File', 'Line', 'Column', 'DefaultLevel', 'Level', 'Category', 'Name', 'Warning',
             'Suggestion', 'Note', 'CWEs', 'Context', 'Fingerprint', 'ToolVersion', 'RuleId', 'HelpUri'
         ])
         return

--- a/flawfinder
+++ b/flawfinder
@@ -378,10 +378,11 @@ class Hit(object):
     extract_lookahead = 0  # Normally don't extract lookahead.
 
     def __init__(self, data):
-        hook, level, warning, suggestion, category, url, other = data
+        hook, level, warning, suggestion, category, url, other, ruleid = data
         self.hook, self.level = hook, level
         self.warning, self.suggestion = warning, suggestion
         self.category, self.url = category, url
+        self.ruleid = ruleid
         # These will be set later, but I set them here so that
         # analysis tools like PyChecker will know about them.
         self.column = 0
@@ -404,7 +405,7 @@ class Hit(object):
     def __ne__(self, other):
         return not self == other
 
-    # return CWEs
+    # Return CWEs
     def cwes(self):
         result = find_cwe_pattern.search(self.warning)
         return result.group()[1:-1] if result else ''
@@ -415,12 +416,21 @@ class Hit(object):
         m.update(self.context_text.strip().encode('utf-8'))
         return m.hexdigest()
 
+    # Help uri for each defined rule. e.g. "https://dwheeler.com/flawfinder#FF1002"
+    # return first CWE link for now
+    def helpuri(self):
+        cwe = re.split(',|!', self.cwes())[0] + ")"
+        return link_cwe_pattern.sub(
+                r'https://cwe.mitre.org/data/definitions/\2.html',
+                cwe)
+
     # Show as CSV format
     def show_csv(self):
         csv_writer.writerow([
             self.filename, self.line, self.column, self.level, self.category,
-            self.name, self.warning, self.suggestion, self.note,
-            self.cwes(), self.context_text, self.fingerprint()
+            self.name, self.warning + ".", self.suggestion + "." if self.suggestion else "", self.note,
+            self.cwes(), self.context_text, self.fingerprint(),
+            version, self.ruleid, self.helpuri()
         ])
 
     def show(self):
@@ -896,7 +906,8 @@ c_ruleset = {
     (c_buffer, 4,
      "Does not check for buffer overflows when copying to destination [MS-banned] (CWE-120)",
      "Consider using snprintf, strcpy_s, or strlcpy (warning: strncpy easily misused)",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1001"),
+
     "strcpyA|strcpyW|StrCpy|StrCpyA|lstrcpyA|lstrcpyW|_tccpy|_mbccpy|_ftcscpy|_mbsncpy|StrCpyN|StrCpyNA|StrCpyNW|StrNCpy|strcpynA|StrNCpyA|StrNCpyW|lstrcpynA|lstrcpynW":
     # We need more info on these functions; I got their names from the
     # Microsoft "banned" list.  For now, just use "normal" to process them
@@ -904,33 +915,39 @@ c_ruleset = {
     (normal, 4,
      "Does not check for buffer overflows when copying to destination [MS-banned] (CWE-120)",
      "Consider using snprintf, strcpy_s, or strlcpy (warning: strncpy easily misused)",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1002"),
+
     "lstrcpy|wcscpy|_tcscpy|_mbscpy":
     (c_buffer, 4,
      "Does not check for buffer overflows when copying to destination [MS-banned] (CWE-120)",
      "Consider using a function version that stops copying at the end of the buffer",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1003"),
+
     "memcpy|CopyMemory|bcopy":
     (c_memcpy, 2,  # I've found this to have a lower risk in practice.
      "Does not check for buffer overflows when copying to destination (CWE-120)",
      "Make sure destination can always hold the source data",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1004"),
+
     "strcat":
     (c_buffer, 4,
      "Does not check for buffer overflows when concatenating to destination [MS-banned] (CWE-120)",
      "Consider using strcat_s, strncat, strlcat, or snprintf (warning: strncat is easily misused)",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1005"),
+
     "lstrcat|wcscat|_tcscat|_mbscat":
     (c_buffer, 4,
      "Does not check for buffer overflows when concatenating to destination [MS-banned] (CWE-120)",
      "",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1006"),
+
     # TODO: Do more analysis.  Added because they're in MS banned list.
     "StrCat|StrCatA|StrcatW|lstrcatA|lstrcatW|strCatBuff|StrCatBuffA|StrCatBuffW|StrCatChainW|_tccat|_mbccat|_ftcscat|StrCatN|StrCatNA|StrCatNW|StrNCat|StrNCatA|StrNCatW|lstrncat|lstrcatnA|lstrcatnW":
     (normal, 4,
      "Does not check for buffer overflows when concatenating to destination [MS-banned] (CWE-120)",
      "",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1007"),
+
     "strncpy":
     (c_buffer,
      1,  # Low risk level, because this is often used correctly when FIXING security
@@ -939,7 +956,8 @@ c_ruleset = {
      "Easily used incorrectly; doesn't always \\0-terminate or "
      "check for invalid pointers [MS-banned] (CWE-120)",
      "",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1008"),
+
     "lstrcpyn|wcsncpy|_tcsncpy|_mbsnbcpy":
     (c_buffer,
      1,  # Low risk level, because this is often used correctly when FIXING security
@@ -948,7 +966,8 @@ c_ruleset = {
      "Easily used incorrectly; doesn't always \\0-terminate or "
      "check for invalid pointers [MS-banned] (CWE-120)",
      "",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1009"),
+
     "strncat":
     (c_strncat,
      1,  # Low risk level, because this is often used correctly when
@@ -956,7 +975,8 @@ c_ruleset = {
      # higher risk level would cause many false positives.
      "Easily used incorrectly (e.g., incorrectly computing the correct maximum size to add) [MS-banned] (CWE-120)",
      "Consider strcat_s, strlcat, snprintf, or automatically resizing strings",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1010"),
+
     "lstrcatn|wcsncat|_tcsncat|_mbsnbcat":
     (c_strncat,
      1,  # Low risk level, because this is often used correctly when FIXING security
@@ -964,42 +984,44 @@ c_ruleset = {
      # positives.
      "Easily used incorrectly (e.g., incorrectly computing the correct maximum size to add) [MS-banned] (CWE-120)",
      "Consider strcat_s, strlcat, or automatically resizing strings",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1011"),
+
     "strccpy|strcadd":
     (normal, 1,
      "Subject to buffer overflow if buffer is not as big as claimed (CWE-120)",
      "Ensure that destination buffer is sufficiently large",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1012"),
+
     "char|TCHAR|wchar_t":  # This isn't really a function call, but it works.
     (c_static_array, 2,
      "Statically-sized arrays can be improperly restricted, "
      "leading to potential overflows or other issues (CWE-119!/CWE-120)",
      "Perform bounds checking, use functions that limit length, "
      "or ensure that the size is larger than the maximum possible length",
-     "buffer", "", {'extract_lookahead': 1}),
+     "buffer", "", {'extract_lookahead': 1}, "FF1013"),
 
     "gets|_getts":
     (normal, 5, "Does not check for buffer overflows (CWE-120, CWE-20)",
-     "Use fgets() instead", "buffer", "", {'input': 1}),
+     "Use fgets() instead", "buffer", "", {'input': 1}, "FF1014"),
 
     # The "sprintf" hook will raise "format" issues instead if appropriate:
     "sprintf|vsprintf|swprintf|vswprintf|_stprintf|_vstprintf":
     (c_sprintf, 4,
      "Does not check for buffer overflows (CWE-120)",
      "Use sprintf_s, snprintf, or vsnprintf",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1015"),
 
     "printf|vprintf|vwprintf|vfwprintf|_vtprintf|wprintf":
     (c_printf, 4,
      "If format strings can be influenced by an attacker, they can be exploited (CWE-134)",
      "Use a constant for the format specification",
-     "format", "", {}),
+     "format", "", {}, "FF1016"),
 
     "fprintf|vfprintf|_ftprintf|_vftprintf|fwprintf|fvwprintf":
     (c_printf, 4,
      "If format strings can be influenced by an attacker, they can be exploited (CWE-134)",
      "Use a constant for the format specification",
-     "format", "", {'format_position': 2}),
+     "format", "", {'format_position': 2}, "FF1017"),
 
     # The "syslog" hook will raise "format" issues.
     "syslog":
@@ -1007,28 +1029,28 @@ c_ruleset = {
      "If syslog's format strings can be influenced by an attacker, "
      "they can be exploited (CWE-134)",
      "Use a constant format string for syslog",
-     "format", "", {'format_position': 2}),
+     "format", "", {'format_position': 2}, "FF1018"),
 
     "snprintf|vsnprintf|_snprintf|_sntprintf|_vsntprintf":
     (c_printf, 4,
      "If format strings can be influenced by an attacker, they can be "
      "exploited, and note that sprintf variations do not always \\0-terminate (CWE-134)",
      "Use a constant for the format specification",
-     "format", "", {'format_position': 3}),
+     "format", "", {'format_position': 3}, "FF1019"),
 
     "scanf|vscanf|wscanf|_tscanf|vwscanf":
     (c_scanf, 4,
      "The scanf() family's %s operation, without a limit specification, "
      "permits buffer overflows (CWE-120, CWE-20)",
      "Specify a limit to %s, or use a different input function",
-     "buffer", "", {'input': 1}),
+     "buffer", "", {'input': 1}, "FF1020"),
 
     "fscanf|sscanf|vsscanf|vfscanf|_ftscanf|fwscanf|vfwscanf|vswscanf":
     (c_scanf, 4,
      "The scanf() family's %s operation, without a limit specification, "
      "permits buffer overflows (CWE-120, CWE-20)",
      "Specify a limit to %s, or use a different input function",
-     "buffer", "", {'input': 1, 'format_position': 2}),
+     "buffer", "", {'input': 1, 'format_position': 2}, "FF1021"),
 
     "strlen|wcslen|_tcslen|_mbslen":
     (normal,
@@ -1039,26 +1061,26 @@ c_ruleset = {
      "if given one it may perform an over-read (it could cause a crash "
      "if unprotected) (CWE-126)",
      "",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1022"),
 
     "MultiByteToWideChar":  # Windows
     (c_multi_byte_to_wide_char,
      2,  # Only the default - this will be changed in many cases.
      "Requires maximum length in CHARACTERS, not bytes (CWE-120)",
      "",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1023"),
 
     "streadd|strecpy":
     (normal, 4,
      "This function does not protect against buffer overflows (CWE-120)",
      "Ensure the destination has 4 times the size of the source, to leave room for expansion",
-     "buffer", "dangers-c", {}),
+     "buffer", "dangers-c", {}, "FF1024"),
 
     "strtrns":
     (normal, 3,
      "This function does not protect against buffer overflows (CWE-120)",
      "Ensure that destination is at least as long as the source",
-     "buffer", "dangers-c", {}),
+     "buffer", "dangers-c", {}, "FF1025"),
 
     "realpath":
     (normal, 3,
@@ -1067,27 +1089,27 @@ c_ruleset = {
      "Ensure that the destination buffer is at least of size MAXPATHLEN, and"
      "to protect against implementation problems, the input argument "
      "should also be checked to ensure it is no larger than MAXPATHLEN",
-     "buffer", "dangers-c", {}),
+     "buffer", "dangers-c", {}, "FF1026"),
 
     "getopt|getopt_long":
     (normal, 3,
      "Some older implementations do not protect against internal buffer overflows (CWE-120, CWE-20)",
      "Check implementation on installation, or limit the size of all string inputs",
-     "buffer", "dangers-c", {'input': 1}),
+     "buffer", "dangers-c", {'input': 1}, "FF1027"),
 
     "getwd":
     (normal, 3,
      "This does not protect against buffer overflows "
      "by itself, so use with caution (CWE-120, CWE-20)",
      "Use getcwd instead",
-     "buffer", "dangers-c", {'input': 1}),
+     "buffer", "dangers-c", {'input': 1}, "FF1028"),
 
     # fread not included here; in practice I think it's rare to mistake it.
     "getchar|fgetc|getc|read|_gettc":
     (normal, 1,
      "Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)",
      "",
-     "buffer", "dangers-c", {'input': 1}),
+     "buffer", "dangers-c", {'input': 1}, "FF1029"),
 
     "access":        # ???: TODO: analyze TOCTOU more carefully.
     (normal, 4,
@@ -1098,31 +1120,36 @@ c_ruleset = {
      "Set up the correct permissions (e.g., using setuid()) and "
      "try to open the file directly",
      "race",
-     "avoid-race#atomic-filesystem", {}),
+     "avoid-race#atomic-filesystem", {}, "FF1030"),
+
     "chown":
     (normal, 5,
      "This accepts filename arguments; if an attacker "
      "can move those files, a race condition results. (CWE-362)",
      "Use fchown( ) instead",
-     "race", "", {}),
+     "race", "", {}, "FF1031"),
+
     "chgrp":
     (normal, 5,
      "This accepts filename arguments; if an attacker "
      "can move those files, a race condition results. (CWE-362)",
      "Use fchgrp( ) instead",
-     "race", "", {}),
+     "race", "", {}, "FF1032"),
+
     "chmod":
     (normal, 5,
      "This accepts filename arguments; if an attacker "
      "can move those files, a race condition results. (CWE-362)",
      "Use fchmod( ) instead",
-     "race", "", {}),
+     "race", "", {}, "FF1033"),
+
     "vfork":
     (normal, 2,
      "On some old systems, vfork() permits race conditions, and it's "
      "very difficult to use correctly (CWE-362)",
      "Use fork() instead",
-     "race", "", {}),
+     "race", "", {}, "FF1034"),
+
     "readlink":
     (normal, 5,
      "This accepts filename arguments; if an attacker "
@@ -1132,43 +1159,44 @@ c_ruleset = {
      # This is often just a bad idea, and it's hard to suggest a
      # simple alternative:
      "Reconsider approach",
-     "race", "", {'input': 1}),
+     "race", "", {'input': 1}, "FF1035"),
 
     "tmpfile":
     (normal, 2,
      "Function tmpfile() has a security flaw on some systems (e.g., older System V systems) (CWE-377)",
      "",
-     "tmpfile", "", {}),
+     "tmpfile", "", {}, "FF1036"),
+
     "tmpnam|tempnam":
     (normal, 3,
      "Temporary file race condition (CWE-377)",
      "",
-     "tmpfile", "avoid-race", {}),
+     "tmpfile", "avoid-race", {}, "FF1037"),
 
     # TODO: Detect GNOME approach to mktemp and ignore it.
     "mktemp":
     (normal, 4,
      "Temporary file race condition (CWE-377)",
      "",
-     "tmpfile", "avoid-race", {}),
+     "tmpfile", "avoid-race", {}, "FF1038"),
 
     "mkstemp":
     (normal, 2,
      "Potential for temporary file vulnerability in some circumstances.  Some older Unix-like systems create temp files with permission to write by all by default, so be sure to set the umask to override this. Also, some older Unix systems might fail to use O_EXCL when opening the file, so make sure that O_EXCL is used by the library (CWE-377)",
      "",
-     "tmpfile", "avoid-race", {}),
+     "tmpfile", "avoid-race", {}, "FF1039"),
 
     "fopen|open":
     (normal, 2,
      "Check when opening files - can an attacker redirect it (via symlinks), force the opening of special file type (e.g., device files), move things around to create a race condition, control its ancestors, or change its contents? (CWE-362)",
      "",
-     "misc", "", {}),
+     "misc", "", {}, "FF1040"),
 
     "umask":
     (normal, 1,
      "Ensure that umask is given most restrictive possible setting (e.g., 066 or 077) (CWE-732)",
      "",
-     "access", "", {}),
+     "access", "", {}, "FF1041"),
 
     # Windows.  TODO: Detect correct usage approaches and ignore it.
     "GetTempFileName":
@@ -1176,7 +1204,7 @@ c_ruleset = {
      "Temporary file race condition in certain cases "
      "(e.g., if run as SYSTEM in many versions of Windows) (CWE-377)",
      "",
-     "tmpfile", "avoid-race", {}),
+     "tmpfile", "avoid-race", {}, "FF1042"),
 
     # TODO: Need to detect varying levels of danger.
     "execl|execlp|execle|execv|execvp|popen|WinExec|ShellExecute":
@@ -1184,7 +1212,7 @@ c_ruleset = {
      "This causes a new program to execute and is difficult to use safely (CWE-78)",
      "try using a library call that implements the same functionality "
      "if available",
-     "shell", "", {}),
+     "shell", "", {}, "FF1043"),
 
     # TODO: Need to detect varying levels of danger.
     "system":
@@ -1192,7 +1220,7 @@ c_ruleset = {
      "This causes a new program to execute and is difficult to use safely (CWE-78)",
      "try using a library call that implements the same functionality "
      "if available",
-     "shell", "", {'extract_lookahead': 1}),
+     "shell", "", {'extract_lookahead': 1}, "FF1044"),
 
     # TODO: Be more specific.  The biggest problem involves "first" param NULL,
     # second param with embedded space. Windows.
@@ -1200,7 +1228,7 @@ c_ruleset = {
     (normal, 3,
      "This causes a new process to execute and is difficult to use safely (CWE-78)",
      "Especially watch out for embedded spaces",
-     "shell", "", {}),
+     "shell", "", {}, "FF1045"),
 
     # TODO: Be more specific.  The biggest problem involves "first" param NULL,
     # second param with embedded space. Windows.
@@ -1209,7 +1237,7 @@ c_ruleset = {
      "This causes a new process to execute and is difficult to use safely (CWE-78)",
      "Specify the application path in the first argument, NOT as part of the second, "
      "or embedded spaces could allow an attacker to force a different program to run",
-     "shell", "", {'check_for_null': 1}),
+     "shell", "", {'check_for_null': 1}, "FF1046"),
 
     "atoi|atol|_wtoi|_wtoi64":
     (normal, 2,
@@ -1218,14 +1246,14 @@ c_ruleset = {
      "If source untrusted, check both minimum and maximum, even if the"
      " input had no minus sign (large numbers can roll over into negative"
      " number; consider saving to an unsigned value if that is intended)",
-     "integer", "dangers-c", {}),
+     "integer", "dangers-c", {}, "FF1047"),
 
     # Random values.  Don't trigger on "initstate", it's too common a term.
     "drand48|erand48|jrand48|lcong48|lrand48|mrand48|nrand48|random|seed48|setstate|srand|strfry|srandom|g_rand_boolean|g_rand_int|g_rand_int_range|g_rand_double|g_rand_double_range|g_random_boolean|g_random_int|g_random_int_range|g_random_double|g_random_double_range":
     (normal, 3,
      "This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)",
      "Use a more secure technique for acquiring random values",
-     "random", "", {}),
+     "random", "", {}, "FF1048"),
 
     "crypt|crypt_r":
     (normal, 4,
@@ -1235,7 +1263,7 @@ c_ruleset = {
      "dictionary attacks given today's faster computing equipment (CWE-327)",
      "Use a different algorithm, such as SHA-256, with a larger, "
      "non-repeating salt",
-     "crypto", "", {}),
+     "crypto", "", {}, "FF1049"),
 
     # OpenSSL EVP calls to use DES.
     "EVP_des_ecb|EVP_des_cbc|EVP_des_cfb|EVP_des_ofb|EVP_desx_cbc":
@@ -1243,7 +1271,7 @@ c_ruleset = {
      "DES only supports a 56-bit keysize, which is too small given today's computers (CWE-327)",
      "Use a different patent-free encryption algorithm with a larger keysize, "
      "such as 3DES or AES",
-     "crypto", "", {}),
+     "crypto", "", {}, "FF1050"),
 
     # Other OpenSSL EVP calls to use small keys.
     "EVP_rc4_40|EVP_rc2_40_cbc|EVP_rc2_64_cbc":
@@ -1251,7 +1279,7 @@ c_ruleset = {
      "These keysizes are too small given today's computers (CWE-327)",
      "Use a different patent-free encryption algorithm with a larger keysize, "
      "such as 3DES or AES",
-     "crypto", "", {}),
+     "crypto", "", {}, "FF1051"),
 
     "chroot":
     (normal, 3,
@@ -1259,14 +1287,14 @@ c_ruleset = {
      "Make sure the program immediately chdir(\"/\"), closes file descriptors,"
      " and drops root privileges, and that all necessary files"
      " (and no more!) are in the new root",
-     "misc", "", {}),
+     "misc", "", {}, "FF1052"),
 
     "getenv|curl_getenv":
     (normal, 3, "Environment variables are untrustable input if they can be"
      " set by an attacker.  They can have any content and"
      " length, and the same variable can be set more than once (CWE-807, CWE-20)",
      "Check environment variables carefully before using them",
-     "buffer", "", {'input': 1}),
+     "buffer", "", {'input': 1}, "FF1053"),
 
     "g_get_home_dir":
     (normal, 3, "This function is synonymous with 'getenv(\"HOME\")';"
@@ -1274,7 +1302,7 @@ c_ruleset = {
      "set by an attacker.  It can have any content and length, "
      "and the same variable can be set more than once (CWE-807, CWE-20)",
      "Check environment variables carefully before using them",
-     "buffer", "", {'input': 1}),
+     "buffer", "", {'input': 1}, "FF1054"),
 
     "g_get_tmp_dir":
     (normal, 3, "This function is synonymous with 'getenv(\"TMP\")';"
@@ -1282,7 +1310,7 @@ c_ruleset = {
      "set by an attacker.  It can have any content and length, "
      "and the same variable can be set more than once (CWE-807, CWE-20)",
      "Check environment variables carefully before using them",
-     "buffer", "", {'input': 1}),
+     "buffer", "", {'input': 1}, "FF1055"),
 
 
     # These are Windows-unique:
@@ -1293,12 +1321,12 @@ c_ruleset = {
     "SetThreadToken":
     (normal, 4, "If this call fails, the program could fail to drop heightened privileges (CWE-250)",
      "Make sure the return value is checked, and do not continue if a failure is reported",
-     "access", "", {}),
+     "access", "", {}, "FF1056"),
 
     "InitializeCriticalSection":
     (normal, 3, "Exceptions can be thrown in low-memory situations",
      "Use InitializeCriticalSectionAndSpinCount instead",
-     "misc", "", {}),
+     "misc", "", {}, "FF1057"),
 
     # We have *removed* the check for EnterCriticalSection.
     # The page from the "book Writing Secure Code" describes
@@ -1316,79 +1344,79 @@ c_ruleset = {
     "LoadLibrary":
     (normal, 3, "Ensure that the full path to the library is specified, or current directory may be used (CWE-829, CWE-20)",
      "Use LoadLibraryEx with one of the search flags, or call SetSearchPathMode to use a safe search path, or pass a full path to the library",
-     "misc", "", {'input': 1}),
+     "misc", "", {'input': 1}, "FF1058"),
 
     "LoadLibraryEx":
     (load_library_ex, 3, "Ensure that the full path to the library is specified, or current directory may be used (CWE-829, CWE-20)",
      "Use a flag like LOAD_LIBRARY_SEARCH_SYSTEM32 or LOAD_LIBRARY_SEARCH_APPLICATION_DIR to search only desired folders",
-     "misc", "", {'input': 1}),
+     "misc", "", {'input': 1}, "FF1059"),
 
     "SetSecurityDescriptorDacl":
     (c_hit_if_null, 5,
      "Never create NULL ACLs; an attacker can set it to Everyone (Deny All Access), "
      "which would even forbid administrator access (CWE-732)",
      "",
-     "misc", "", {'check_for_null': 3}),
+     "misc", "", {'check_for_null': 3}, "FF1060"),
 
     "AddAccessAllowedAce":
     (normal, 3,
      "This doesn't set the inheritance bits in the access control entry (ACE) header (CWE-732)",
      "Make sure that you set inheritance by hand if you wish it to inherit",
-     "misc", "", {}),
+     "misc", "", {}, "FF1061"),
 
     "getlogin":
     (normal, 4,
      "It's often easy to fool getlogin.  Sometimes it does not work at all, because some program messed up the utmp file.  Often, it gives only the first 8 characters of the login name. The user currently logged in on the controlling tty of our program need not be the user who started it.  Avoid getlogin() for security-related purposes (CWE-807)",
      "Use getpwuid(geteuid()) and extract the desired information instead",
-     "misc", "", {}),
+     "misc", "", {}, "FF1062"),
 
     "cuserid":
     (normal, 4,
      "Exactly what cuserid() does is poorly defined (e.g., some systems use the effective uid, like Linux, while others like System V use the real uid). Thus, you can't trust what it does. It's certainly not portable (The cuserid function was included in the 1988 version of POSIX, but removed from the 1990 version).  Also, if passed a non-null parameter, there's a risk of a buffer overflow if the passed-in buffer is not at least L_cuserid characters long (CWE-120)",
      "Use getpwuid(geteuid()) and extract the desired information instead",
-     "misc", "", {}),
+     "misc", "", {}, "FF1063"),
 
     "getpw":
     (normal, 4,
      "This function is dangerous; it may overflow the provided buffer. It extracts data from a 'protected' area, but most systems have many commands to let users modify the protected area, and it's not always clear what their limits are.  Best to avoid using this function altogether (CWE-676, CWE-120)",
      "Use getpwuid() instead",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1064"),
 
     "getpass":
     (normal, 4,
      "This function is obsolete and not portable. It was in SUSv2 but removed by POSIX.2.  What it does exactly varies considerably between systems, particularly in where its prompt is displayed and where it gets its data (e.g., /dev/tty, stdin, stderr, etc.). In addition, some implementations overflow buffers. (CWE-676, CWE-120, CWE-20)",
      "Make the specific calls to do exactly what you want.  If you continue to use it, or write your own, be sure to zero the password as soon as possible to avoid leaving the cleartext password visible in the process' address space",
-     "misc", "", {'input': 1}),
+     "misc", "", {'input': 1}, "FF1065"),
 
     "gsignal|ssignal":
     (normal, 2,
      "These functions are considered obsolete on most systems, and very non-portable (Linux-based systems handle them radically different, basically if gsignal/ssignal were the same as raise/signal respectively, while System V considers them a separate set and obsolete) (CWE-676)",
      "Switch to raise/signal, or some other signalling approach",
-     "obsolete", "", {}),
+     "obsolete", "", {}, "FF1066"),
 
     "memalign":
     (normal, 1,
      "On some systems (though not Linux-based systems) an attempt to free() results from memalign() may fail. This may, on a few systems, be exploitable.  Also note that memalign() may not check that the boundary parameter is correct (CWE-676)",
      "Use posix_memalign instead (defined in POSIX's 1003.1d).  Don't switch to valloc(); it is marked as obsolete in BSD 4.3, as legacy in SUSv2, and is no longer defined in SUSv3.  In some cases, malloc()'s alignment may be sufficient",
-     "free", "", {}),
+     "free", "", {}, "FF1067"),
 
     "ulimit":
     (normal, 1,
      "This C routine is considered obsolete (as opposed to the shell command by the same name, which is NOT obsolete) (CWE-676)",
      "Use getrlimit(2), setrlimit(2), and sysconf(3) instead",
-     "obsolete", "", {}),
+     "obsolete", "", {}, "FF1068"),
 
     "usleep":
     (normal, 1,
      "This C routine is considered obsolete (as opposed to the shell command by the same name).   The interaction of this function with SIGALRM and other timer functions such as sleep(), alarm(), setitimer(), and nanosleep() is unspecified (CWE-676)",
      "Use nanosleep(2) or setitimer(2) instead",
-     "obsolete", "", {}),
+     "obsolete", "", {}, "FF1069"),
 
     # Input functions, useful for -I
     "recv|recvfrom|recvmsg|fread|readv":
     (normal, 0, "Function accepts input from outside program (CWE-20)",
      "Make sure input data is filtered, especially if an attacker could manipulate it",
-     "input", "", {'input': 1}),
+     "input", "", {'input': 1}, "FF1070"),
 
     # Unsafe STL functions that don't check the second iterator
     "equal|mismatch|is_permutation":
@@ -1398,7 +1426,7 @@ c_ruleset = {
      1,
      "Function does not check the second iterator for over-read conditions (CWE-126)",
      "This function is often discouraged by most C++ coding standards in favor of its safer alternatives provided since C++14. Consider using a form of this function that checks the second iterator before potentially overflowing it",
-     "buffer", "", {}),
+     "buffer", "", {}, "FF1071"),
 
     # TODO: detect C++'s:   cin >> charbuf, where charbuf is a char array; the problem
     #       is that flawfinder doesn't have type information, and ">>" is safe with
@@ -1759,7 +1787,7 @@ def display_header():
     if csv_output:
         csv_writer.writerow([
             'File', 'Line', 'Column', 'Level', 'Category', 'Name', 'Warning',
-            'Suggestion', 'Note', 'CWEs', 'Context', 'Fingerprint'
+            'Suggestion', 'Note', 'CWEs', 'Context', 'Fingerprint', 'ToolVersion', 'RuleId', 'HelpUri'
         ])
         return
     if not showheading:


### PR DESCRIPTION
Related to #33 
* Assigned Sarif friendly opaque rule id.
* Export rule id to csv
* Export rule help uri to csv
* Export version to csv
* Add period to messages in csv. 