### PR TITLE
entrypoint.sh: Modify to use "$@"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -l
-# $1 arguments. BEWARE: Some filenames may need to be escaped.
+# $1 whitespace-separated arguments. Some filenames may need to be escaped.
 # $2 output filename
 
-flawfinder "$@" > "$2"
+flawfinder $1 | tee "$2"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,4 @@
 # $1 arguments. BEWARE: Some filenames may need to be escaped.
 # $2 output filename
 
-flawfinder $1 > "$2"
-
-echo "Executed with success."
+flawfinder "$@" > "$2"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,10 @@
 # $1 whitespace-separated arguments. Some filenames may need to be escaped.
 # $2 output filename
 
-flawfinder $1 | tee "$2"
+output="${2:-flawfinder-output.txt}"
+
+flawfinder $1 > "$output"
+result="$?"
+
+cat "$output"
+exit "$result"


### PR DESCRIPTION
Modify entrypoint.sh, used by the Dockerfile.

The previous version of entrypoint.sh only used the first parameter.
What's worse, it would double-expand globs
(referring to "*.c", if a file was named *.c, that would get
expanded again). Usually variable references in shell are quoted.

In addition, the original version *ALWAYS* echoed a success,
even if the command did NOT succeed for some reason.
Instead of printing the spurious message, just show the output and
let the exit value get communicated back to the caller.
This is especially important for CI/CD, since we want the CI/CD
system to get the exit value (e.g., so it can report failure if there
was a failure).

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>