### PR TITLE
print warning messages to stderr

### DIFF
--- a/flawfinder.py
+++ b/flawfinder.py
@@ -675,7 +675,7 @@ def add_warning(hit):
 
 
 def internal_warn(message):
-    print(h(message))
+    print(h(message), file=sys.stderr)
 
 
 # C Language Specific


### PR DESCRIPTION
Modify the internal_warn function so that it prints to stderr instead of stdout so that the CSV output is not corrupted with non-CSV content.  This would solve issue #57 