### PR TITLE
Optimize builtin SPEC file

### DIFF
--- a/flawfinder.spec
+++ b/flawfinder.spec
@@ -1,14 +1,20 @@
-Name: flawfinder
-Summary: Examines C/C++ source code for security flaws
-Version: 2.0.18
-Release: 1%{?dist}
-License: GPLv2+
-Group: Development/Tools
-URL: http://dwheeler.com/flawfinder/
-Source: http://dwheeler.com/flawfinder/%{name}-%{version}.tar.gz
-Requires: python
-BuildArch: noarch
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Name:              flawfinder
+Summary:           Examines C/C++ source code for security flaws
+Version:           2.0.19
+Release:           1%{?dist}
+Group:             Development/Tools
+
+License:           GPLv2+
+URL:               http://dwheeler.com/flawfinder/
+Source:            http://dwheeler.com/flawfinder/%{name}-%{version}.tar.gz
+
+BuildArch:         noarch
+BuildRequires:     flex
+BuildRequires:     make
+BuildRoot:         %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+Provides:          flawfinder = %{version}-%{release}
+Requires:          python
 
 %description
 Flawfinder scans through C/C++ source code,
@@ -19,12 +25,10 @@ By default it reports hits sorted by severity, with the riskiest lines first.
 %setup  -q
 
 %build
-make %{?_smp_mflags}
+%{__make} %{?_smp_mflags}
 
 %install
-rm -rf $RPM_BUILD_ROOT
-install -m755 -D flawfinder ${RPM_BUILD_ROOT}%{_bindir}/flawfinder
-install -m644 -D flawfinder.1 ${RPM_BUILD_ROOT}%{_mandir}/man1/flawfinder.1
+%{__make} install DESTDIR=${RPM_BUILD_ROOT} prefix=%{_usr}
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -36,6 +40,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/*
 
 %changelog
+* Tue Sep 21 2021 Weilun Fong <wlf@zhishan-iot.tk>
+- Improve install command
+- Add <Provides> SPEC Directive
+
 * Mon Aug 27 2007 Horst H. von Brand <vonbrand@inf.utfsm.cl>  1.27-2
 - Fix specfile as per Fedora guidelines
 
@@ -43,5 +51,3 @@ rm -rf $RPM_BUILD_ROOT
 - changed build architecture to noarch
 - replaced hardcoded directories by rpm macros
 - removed several rpmlint warnings/errors
-
-# vim:set ai ts=4 sw=4:

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@
 # how to change version numbers.
 
 NAME=flawfinder
-VERSION=2.0.18
+VERSION=2.0.19
 RPM_VERSION=1
 VERSIONEDNAME=$(NAME)-$(VERSION)
 ARCH=noarch
@@ -19,7 +19,7 @@ SAMPLE_DIR=/usr/src/linux-2.2.16
 # not notice any changes.  We define exec_prefix oddly so we can
 # quietly merge these 2 systems:
 
-prefix=/usr/local
+prefix?=/usr/local
 INSTALL_DIR=$(prefix)
 exec_prefix=$(INSTALL_DIR)
 bindir=$(exec_prefix)/bin
@@ -44,7 +44,7 @@ PYTHONEXT=
 
 RPMBUILD=rpmbuild
 
-DESTDIR=
+DESTDIR?=
 
 TESTDIR=test/
 


### PR DESCRIPTION
I found some problems during I am building rpm package for version 2.0.19. So I try modifying current builtin SPEC file, mainly including:

* Optimize writing with popular style.
* Add `Provides` SPEC Directive, it's very important for a RPM package! Besides, I also add `flex`  into `BuildRequires` because many machines don't install it in advanced.
* Modify install command with standard way. If we need add or delete files in the future, it will be convenient for developers.

Besieds, I modify makefile because variable `DESTDIR` is fixed. However, SPEC usually passes root path to makefile by this variable. So I adjust assignment way of related variables.

I test this commit well on my CentOS 7 machine
```
[wlf@localhost SPECS]$ rpmbuild -ba flawfinder.spec
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.gmfe1A
+ umask 022
+ cd /home/wlf/rpmbuild/BUILD
+ cd /home/wlf/rpmbuild/BUILD
+ rm -rf flawfinder-2.0.19
+ /usr/bin/gzip -dc /home/wlf/rpmbuild/SOURCES/flawfinder-2.0.19.tar.gz
+ /usr/bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd flawfinder-2.0.19
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.LhabPV
+ umask 022
+ cd /home/wlf/rpmbuild/BUILD
+ cd flawfinder-2.0.19
+ /usr/bin/make -j16
chmod -R a+rX *
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.ub78Dg
+ umask 022
+ cd /home/wlf/rpmbuild/BUILD
+ '[' /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64 '!=' / ']'
+ rm -rf /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64
++ dirname /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64
+ mkdir -p /home/wlf/rpmbuild/BUILDROOT
+ mkdir /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64
+ cd flawfinder-2.0.19
+ /usr/bin/make install DESTDIR=/home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64 prefix=/usr
mkdir -p "/home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/bin"
cp -p flawfinder.py "/home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/bin/flawfinder"
chmod a+x "/home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/bin/flawfinder"
mkdir -p "/home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/man/man1"
cp -p flawfinder.1 "/home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/man/man1/flawfinder.1"
+ /usr/lib/rpm/find-debuginfo.sh --strict-build-id -m --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 110000000 /home/wlf/rpmbuild/BUILD/flawfinder-2.0.19
/usr/lib/rpm/sepdebugcrcfix: Updated 0 CRC32s, 0 CRC32s did match.
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/redhat/brp-compress
+ /usr/lib/rpm/redhat/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
+ /usr/lib/rpm/redhat/brp-python-hardlink
+ /usr/lib/rpm/redhat/brp-java-repack-jars
Processing files: flawfinder-2.0.19-1.el7.centos.noarch
Executing(%doc): /bin/sh -e /var/tmp/rpm-tmp.xzcEJB
+ umask 022
+ cd /home/wlf/rpmbuild/BUILD
+ cd flawfinder-2.0.19
+ DOCDIR=/home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/doc/flawfinder-2.0.19
+ export DOCDIR
+ /usr/bin/mkdir -p /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/doc/flawfinder-2.0.19
+ cp -pr README.md /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/doc/flawfinder-2.0.19
+ cp -pr ChangeLog /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/doc/flawfinder-2.0.19
+ cp -pr COPYING /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/doc/flawfinder-2.0.19
+ cp -pr flawfinder.ps /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64/usr/share/doc/flawfinder-2.0.19
+ exit 0
Provides: flawfinder = 2.0.19-1.el7.centos
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: /usr/bin/env
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64
Wrote: /home/wlf/rpmbuild/SRPMS/flawfinder-2.0.19-1.el7.centos.src.rpm
Wrote: /home/wlf/rpmbuild/RPMS/noarch/flawfinder-2.0.19-1.el7.centos.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.RkiU4D
+ umask 022
+ cd /home/wlf/rpmbuild/BUILD
+ cd flawfinder-2.0.19
+ rm -rf /home/wlf/rpmbuild/BUILDROOT/flawfinder-2.0.19-1.el7.centos.x86_64
+ exit 0
[wlf@localhost SPECS]$ sudo rpm -ivh ../RPMS/noarch/flawfinder-2.0.19-1.el7.centos.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:flawfinder-2.0.19-1.el7.centos   ################################# [100%]
[wlf@localhost SPECS]$ flawfinder --version
2.0.19
```

Look foward to your reviews, thx!