### PR TITLE
Add a closing tag (</li>)

### DIFF
--- a/flawfinder.py
+++ b/flawfinder.py
@@ -644,6 +644,8 @@ class Hit(object):
             print_multi_line(main_text)
         if output_format:
             print(" </i>", end='')
+        if output_format:
+            print("</li>", end='')
         print()
         if show_context:
             if output_format:


### PR DESCRIPTION
A closing tag for the `li` tag is missing