### PR TITLE
Update CWE list delimiters

### DIFF
--- a/flawfinder.py
+++ b/flawfinder.py
@@ -589,7 +589,7 @@ class Hit(object):
     def helpuri(self):
         if self.cwes() == '':
             return 'https://dwheeler.com/flawfinder#{}'.format(self.ruleid)
-        cwe = re.split(',|!', self.cwes())[0] + ")"
+        cwe = re.split('[,!/]', self.cwes())[0] + ")"
         return link_cwe_pattern.sub(
                 r'https://cwe.mitre.org/data/definitions/\2.html',
                 cwe)


### PR DESCRIPTION
Allow `/` delimiter for CWE list to generate proper helpuri entries for FF1026 & FF1030
Fixes #78