### PR TITLE
test_007: skip if setuptools not installed

### DIFF
--- a/release_process.md
+++ b/release_process.md
@@ -9,14 +9,16 @@ dependencies such as `setuptools` and `twine` are available:
 
 ~~~~
 python3 -m venv venv
-source venv/bin/activate
+source venv/bin/activate   # re-run this in each new shell session
 pip install setuptools twine wheel
 ~~~~
 
 ## Changing version number
 
 Ensure that the version number is the intended final value.
-Make sure every release has a unique version number.
+Make sure every different release has a unique version number,
+and that the number is consistent across all our files for
+a given release.
 
 To change version number, edit the following files:
 makefile
@@ -25,10 +27,12 @@ flawfinder.spec
 setup.py
 index.html # in dwheeler.com/flawfinder
 
-Then run several times:
+Run `make check` until the output stabilises, then accept the new
+expected results:
 
 ~~~~
-make test ; make test-is-correct # update version number in tests
+make check
+make test-is-correct
 ~~~~
 
 ## Test it
@@ -64,8 +68,8 @@ Once you're sure this is the *real* version, tag it:
 
 ~~~~
 git tag VERSION
-git push --tags origin # SourceForge
-git push --tags github # GitHub
+git push --tags sourceforge # SourceForge
+git push --tags origin # (or "github") GitHub
 ~~~~
 
 ## Create tarball
@@ -90,7 +94,9 @@ Do this *before* creating the PyPi distribution package for pip.
 ## Post to pip
 
 First, ensure the packaging tools are installed (see venv setup above).
-On Cygwin you may also need:
+
+On Windows (Cygwin), pip may not be available yet and
+must be bootstrapped first:
 
 ~~~~
 python -m ensurepip

--- a/release_process.md
+++ b/release_process.md
@@ -2,6 +2,17 @@
 
 Here's information on how to release an update to flawfinder.
 
+## Set up a virtual environment
+
+It is recommended to work inside a virtual environment to ensure
+dependencies such as `setuptools` and `twine` are available:
+
+~~~~
+python3 -m venv venv
+source venv/bin/activate
+pip install setuptools twine wheel
+~~~~
+
 ## Changing version number
 
 Ensure that the version number is the intended final value.
@@ -22,8 +33,23 @@ make test ; make test-is-correct # update version number in tests
 
 ## Test it
 
+Run the test suite with the default Python 3 interpreter:
+
 ~~~~
-make check # Run tests in Python 2 and 3
+make check
+~~~~
+
+To test with a specific Python version, set the `PYTHON` variable:
+
+~~~~
+make PYTHON=python3.11 check
+~~~~
+
+Python 2 testing is no longer required (installing Python 2 is
+increasingly difficult), but can be done the same way if available:
+
+~~~~
+make PYTHON=python2 check
 ~~~~
 
 ## Commit it
@@ -63,17 +89,15 @@ Do this *before* creating the PyPi distribution package for pip.
 
 ## Post to pip
 
-First, install the programs to create a PyPi distribution package
-if they are not already installed.  On Cygwin first run:
+First, ensure the packaging tools are installed (see venv setup above).
+On Cygwin you may also need:
 
 ~~~~
 python -m ensurepip
 pip install --upgrade pip
-pip install wheel
-pip install twine
 ~~~~
 
-Then create a PyPi distribution package (for Python2 and Python3):
+Then create a PyPi distribution package:
 
 ~~~~
 make pypi

--- a/test/makefile
+++ b/test/makefile
@@ -50,9 +50,13 @@ test_006: $(FLAWFINDER) test.c
 
 test_007: $(SETUPPY)
 	@echo 'test_007 (setup.py sane)'
-	@test "`$(PYTHON) $(SETUPPY) --name`" = 'flawfinder'
-	@test "`$(PYTHON) $(SETUPPY) --license`" = 'GPL-2.0+'
-	@test "`$(PYTHON) $(SETUPPY) --author`" = 'David A. Wheeler'
+	@if $(PYTHON) -c 'import setuptools' 2>/dev/null; then \
+		test "`$(PYTHON) $(SETUPPY) --name`" = 'flawfinder' && \
+		test "`$(PYTHON) $(SETUPPY) --license`" = 'GPL-2.0+' && \
+		test "`$(PYTHON) $(SETUPPY) --author`" = 'David A. Wheeler'; \
+	else \
+		echo '  SKIP: setuptools not installed'; \
+	fi
 
 test_008: $(FLAWFINDER) test.c
 	@echo 'test_008 (diff hitlist)'

--- a/test/makefile
+++ b/test/makefile
@@ -55,7 +55,7 @@ test_007: $(SETUPPY)
 		test "`$(PYTHON) $(SETUPPY) --license`" = 'GPL-2.0+' && \
 		test "`$(PYTHON) $(SETUPPY) --author`" = 'David A. Wheeler'; \
 	else \
-		echo '  SKIP: setuptools not installed'; \
+		echo '  SKIP: setuptools not installed (fix: pip3 install setuptools)'; \
 	fi
 
 test_008: $(FLAWFINDER) test.c


### PR DESCRIPTION
On macOS (and other systems where setuptools is not installed), setup.py fails at import time with ModuleNotFoundError. Wrap the test in a shell conditional so it skips with a message rather than hard-failing when setuptools is absent.