### PR TITLE
Skip C++11 attribute specifiers like __attribute__((...)) (fixes #107)

### DIFF
--- a/flawfinder.py
+++ b/flawfinder.py
@@ -1921,6 +1921,42 @@ def _skip_attribute_args(text, pos):
     return pos
 
 
+def _skip_cxx_attribute(text, pos):
+    """Advance past a C++11/C23 attribute specifier "[[...]]".
+
+    "pos" must point at the first "[".  Returns the position just after the
+    closing "]]", or "pos" unchanged if this is not a well-formed attribute
+    (in which case the caller simply keeps scanning as before).
+
+    Attribute arguments are metadata, not calls: in
+    "[[gnu::format(printf, 1, 2)]]" the token "printf" names a format
+    family, exactly as it does in the equivalent
+    "__attribute__((format(printf, 1, 2)))" spelling that
+    _skip_attribute_args() already skips.
+
+    Limitation: bracket counting ignores string literals, so an unbalanced
+    "[" or "]" inside an attribute string argument (e.g.
+    deprecated("a[b")) makes the specifier look malformed and it is left
+    unskipped.  This is the conservative direction (no text is lost) and
+    such strings are very rare.
+    """
+    n = len(text)
+    if not text.startswith('[[', pos):
+        return pos
+    depth = 0
+    i = pos
+    while i < n:
+        ch = text[i]
+        if ch == '[':
+            depth += 1
+        elif ch == ']':
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return pos  # No closing "]]" found; do not skip anything.
+
+
 def process_directive():
     "Given a directive, process it."
     global ignoreline, num_ignored_hits
@@ -2133,6 +2169,13 @@ def process_c_file(f, patch_infos):
             elif c == "'":
                 instring = 2
                 codeinline = 1
+            elif c == '[' and nextc == '[':
+                # C++11/C23 attribute specifier; its contents are metadata,
+                # not calls.  Skip it like __attribute__((...)) below.
+                codeinline = 1
+                # max() guards against a malformed specifier, where
+                # _skip_cxx_attribute() returns its starting position.
+                i = max(i, _skip_cxx_attribute(text, i - 1))
             else:
                 codeinline = 1  # It's not whitespace, comment, or string.
                 m = p_c_word.match(text, i - 1)

--- a/test/correct-results-016.txt
+++ b/test/correct-results-016.txt
@@ -1,0 +1,3 @@
+test-cxx-attribute.cpp:21:5:  [4] (format) printf:
+  If format strings can be influenced by an attacker, they can be exploited
+  (CWE-134). Use a constant for the format specification.

--- a/test/makefile
+++ b/test/makefile
@@ -112,12 +112,20 @@ test_012: $(FLAWFINDER) test-modern-cpp.cpp
 	  test-modern-cpp.cpp > test-results-012.txt
 	@diff -u correct-results-012.txt test-results-012.txt
 
+test_016: $(FLAWFINDER) test-cxx-attribute.cpp
+	@echo 'test_016 ([[gnu::format(printf,...)]] not flagged; real calls still flagged)'
+# The C++11 attribute spelling [[...]] must be skipped like the GNU
+# __attribute__((...)) spelling; real printf calls must still fire.
+	@$(PYTHON) $(FLAWFINDER) --omittime -m0 -DC --quiet \
+	  test-cxx-attribute.cpp > test-results-016.txt
+	@diff -u correct-results-016.txt test-results-016.txt
+
 # Run all tests on *one* version of Python;
 # output shows differences from expected results.
 # If everything works as expected, it just prints test numbers.
 # Set PYTHON as needed, including to ""
 test: test_001 test_002 test_003 test_004 test_005 test_006 test_007 test_008 \
-	  test_009 test_010 test_011 test_012 test_013 test_014
+	  test_009 test_010 test_011 test_012 test_013 test_014 test_016
 	@echo 'All tests pass!'
 
 check: test
@@ -134,5 +142,6 @@ test-is-correct: test-results.txt
 	cp -p test-results-011.txt correct-results-011.txt
 	cp -p test-results-012.txt correct-results-012.txt
 	cp -p test-results-013.txt correct-results-013.txt
+	cp -p test-results-016.txt correct-results-016.txt
 
 .PHONY: test check test-is-correct

--- a/test/test-cxx-attribute.cpp
+++ b/test/test-cxx-attribute.cpp
@@ -1,0 +1,22 @@
+// test-cxx-attribute.cpp: the C++11 attribute spelling [[...]] must be
+// skipped exactly like the GNU __attribute__((...)) spelling, so that a
+// dangerous function name used as attribute metadata is not reported as
+// a call.  Real calls outside attributes must still be flagged.
+
+// --- These should produce NO hits ---
+
+// Standard spelling of __attribute__((format(printf, 1, 2))).
+[[gnu::format(printf, 1, 2)]] void my_log(const char *fmt, ...);
+
+// Several attributes in one specifier, with nested parens.
+[[gnu::format(printf, 1, 2), gnu::nonnull(1)]] void my_warn(const char *fmt, ...);
+
+// Attribute after the declarator, and a using-prefixed form.
+void my_note(const char *fmt, ...) [[gnu::format(printf, 1, 2)]];
+[[using gnu: format(printf, 1, 2)]] void my_info(const char *fmt, ...);
+
+// --- These SHOULD still produce hits ---
+
+void real_call(const char *name) {
+    printf(name);  // non-constant format: real hit
+}


### PR DESCRIPTION
Fixes #107.

`__attribute__((format(printf, 1, 2)))` is already skipped: the scanner
recognises the `__attribute__` keyword and calls `_skip_attribute_args()`, with
`test_014` covering it. The standard C++11/C23 spelling of the same thing,
`[[gnu::format(printf, 1, 2)]]`, is not handled at all, so `printf` inside it is
treated as a call and reported as FF1016.

The two spellings mean the same to the compiler:

```console
$ flawfinder --quiet --dataonly attr_gnu.c      # __attribute__((format(printf, 1, 2)))
$ flawfinder --quiet --dataonly attr_cxx.cpp    # [[gnu::format(printf, 1, 2)]]
attr_cxx.cpp:2:  [4] (format) printf:
  If format strings can be influenced by an attacker, they can be exploited
  (CWE-134). Use a constant for the format specification.
```

This adds `_skip_cxx_attribute()`, which counts bracket depth and returns the
position just past the closing `]]`. If no balanced closing bracket is found it
returns its starting position and nothing is skipped, so a malformed specifier
can never swallow the rest of the file. The caller only ever moves forward. As
with `_skip_attribute_args()`, bracket counting ignores string literals; an
unbalanced bracket inside an attribute string argument leaves the specifier
unskipped, which is the safe direction. This is noted in the docstring.

Deciding this is purely lexical — no types or values are involved, only the
`[[` ... `]]` token pair.

New `test_016` with `test/test-cxx-attribute.cpp` covers four forms (plain,
several attributes in one specifier, an attribute after the declarator, and
`[[using gnu: ...]]`) and keeps a real `printf(name)` call that must still be
reported.

No existing expected-results file changes. Checked for regressions on
`nlohmann/json`'s `single_include/nlohmann/json.hpp` (27,012 lines, 11
occurrences of `[[`, including `[[deprecated("Since " #since)]]`,
`[[no_unique_address]]` and a `// [[fill] align]` comment): output is
byte-identical before and after.

`cd test && make test PYTHON=python3` passes, and
`pylint --rcfile=pylintrc flawfinder.py` stays at 10.00/10.
